### PR TITLE
support decoder

### DIFF
--- a/src/__tests__/_fixtures/firestore-schema.ts
+++ b/src/__tests__/_fixtures/firestore-schema.ts
@@ -1,3 +1,4 @@
+import dayjs, { Dayjs } from 'dayjs'
 import {
   $adapter,
   $allow,
@@ -23,6 +24,7 @@ export type IUser = {
   timestamp: FTypes.Timestamp
   options: { a: boolean; b: string }
 }
+export type IUserLocal = Type.Merge<IUser, { timestamp: Dayjs }>
 export type IUserJson = Type.Merge<IUser, { timestamp: string }>
 
 export type IPostA = {
@@ -37,7 +39,15 @@ export type IPostB = {
 const VersionSchema = $documentSchema<IVersion>()
 const VersionAdapter = $collectionAdapter<IVersion>()({})
 
-export const UserSchema = $documentSchema<IUser>()
+export const UserSchema = $documentSchema<IUser, IUserLocal>({
+  decoder: (snap: FTypes.QueryDocumentSnap<IUser>): IUserLocal => {
+    const data = snap.data()
+    return {
+      ...data,
+      timestamp: dayjs(data.timestamp.toDate()),
+    }
+  },
+})
 const UserAdapter = $collectionAdapter<IUser>()({
   selectors: (q) => ({
     teen: () => q.where('age', '>=', 10).where('age', '<', 20),

--- a/src/__tests__/_fixtures/firestore-schema.ts
+++ b/src/__tests__/_fixtures/firestore-schema.ts
@@ -48,7 +48,7 @@ export const UserSchema = $documentSchema<IUser, IUserLocal>({
     }
   },
 })
-const UserAdapter = $collectionAdapter<IUser>()({
+const UserAdapter = $collectionAdapter<IUserLocal>()({
   selectors: (q) => ({
     teen: () => q.where('age', '>=', 10).where('age', '<', 20),
   }),

--- a/src/__tests__/firestore/controller.test.ts
+++ b/src/__tests__/firestore/controller.test.ts
@@ -18,6 +18,16 @@ import { expectEqualRef } from '../_utils/firestore'
 const r = collections($web)
 const ur = collections($webUnauthed)
 
+type UserU = IUserLocal &
+  STypes.DocumentMeta<fadmin.Firestore> &
+  STypes.HasLoc<['versions', 'users']> &
+  STypes.HasT<IUser>
+
+type PostU = (IPostA | IPostB) &
+  STypes.DocumentMeta<fadmin.Firestore> &
+  STypes.HasLoc<['versions', 'users', 'posts']> &
+  STypes.HasT<IPostA | IPostB>
+
 describe('types', () => {
   test('UAt', () => {
     expectType<typeof r.user>(
@@ -64,11 +74,7 @@ describe('refs', () => {
       path,
     )
 
-    expectType<
-      firebase.firestore.DocumentReference<
-        (IPostA | IPostB) & { __loc__: ['versions', 'users', 'posts'] }
-      >
-    >(actualPostRef)
+    expectType<firebase.firestore.DocumentReference<PostU>>(actualPostRef)
 
     expectType<
       firebase.firestore.DocumentReference<
@@ -96,11 +102,7 @@ describe('refs', () => {
   test('parentOfCollection', () => {
     const user = $web.parentOfCollection(r.posts.ref)
 
-    expectType<
-      firebase.firestore.DocumentReference<
-        IUserLocal & { __loc__: ['versions', 'users'] }
-      >
-    >(user)
+    expectType<firebase.firestore.DocumentReference<UserU>>(user)
     expect(user.path).toBe(r.user.path)
   })
 })
@@ -116,7 +118,7 @@ describe('read', () => {
     const snap = await r.user.get()
     const data = snap.data()! // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
-    expectType<IUserLocal & STypes.DocumentMeta<fadmin.Firestore>>(data)
+    expectType<UserU>(data)
     expect(data).toMatchObject({
       ...userData,
       timestamp: expect.anything(),
@@ -130,11 +132,7 @@ describe('read', () => {
     expect(snap.docs).toHaveLength(1)
     const data = snap.docs[0].data()
 
-    expectType<
-      IUser &
-        STypes.DocumentMeta<fadmin.Firestore> &
-        STypes.HasLoc<['versions', 'users']>
-    >(data)
+    expectType<UserU>(data)
     expect(data).toMatchObject({
       ...userData,
       timestamp: expect.anything(),

--- a/src/__tests__/firestore/controller.test.ts
+++ b/src/__tests__/firestore/controller.test.ts
@@ -2,9 +2,10 @@ import { assertFails, assertSucceeds } from '@firebase/testing'
 import { isDayjs } from 'dayjs'
 import { expectType } from 'tsd'
 import { STypes } from '../..'
-import { fadmin } from '../../types/_firestore'
+import { fadmin, fweb } from '../../types/_firestore'
 import { userData } from '../_fixtures/data'
 import {
+  firestoreSchema,
   IPostA,
   IPostB,
   IUser,
@@ -16,6 +17,39 @@ import { expectEqualRef } from '../_utils/firestore'
 
 const r = collections($web)
 const ur = collections($webUnauthed)
+
+describe('types', () => {
+  test('UAt', () => {
+    expectType<typeof r.user>(
+      {} as fweb.DocumentReference<
+        STypes.UAt<
+          fweb.Firestore,
+          typeof firestoreSchema,
+          ['versions', 'users']
+        >
+      >,
+    )
+    expectType<
+      fweb.DocumentReference<
+        STypes.UAt<
+          fweb.Firestore,
+          typeof firestoreSchema,
+          ['versions', 'users']
+        >
+      >
+    >(r.user)
+
+    expectType<typeof r.post>(
+      {} as fweb.DocumentReference<
+        STypes.UAt<
+          fweb.Firestore,
+          typeof firestoreSchema,
+          ['versions', 'users', 'posts']
+        >
+      >,
+    )
+  })
+})
 
 describe('refs', () => {
   test('collection', () => {

--- a/src/_transformer/main.ts
+++ b/src/_transformer/main.ts
@@ -1,5 +1,5 @@
 import { dirname, relative, resolve } from 'path'
-import { createWrappedNode } from 'ts-morph'
+import { createWrappedNode, Node } from 'ts-morph'
 import ts, { factory } from 'typescript'
 import { transformDocumentSchemaNode } from './document-schema'
 import { transformJsonSchemaNode } from './json-schema'
@@ -98,7 +98,16 @@ function visitNode(node: ts.Node, program: ts.Program): ts.Node | undefined {
   }
 
   if (expression.type === documentSchema) {
-    return transformDocumentSchemaNode(typeArgument)
+    const firstArgument = wrappedExpression.getArguments()[0] as
+      | Node<ts.Node>
+      | undefined
+    const visitedNode =
+      firstArgument && visitNode(firstArgument.compilerNode, program)
+
+    return transformDocumentSchemaNode(
+      typeArgument,
+      visitedNode && createWrappedNode(visitedNode),
+    )
   } else {
     const file = node.getSourceFile()
     runtypesImportFlags.set(file.fileName, true)

--- a/src/firestore/STypes.ts
+++ b/src/firestore/STypes.ts
@@ -1,5 +1,6 @@
 import { Type } from '../lib/type'
 import { FTypes } from '../types/FTypes'
+import { GetDeep, Loc } from '../types/_object'
 import {
   $adapter,
   $allow,
@@ -108,12 +109,24 @@ export declare namespace STypes {
     select: Selectors<L, SL, F>
   }
 
+  export type EnsureOptions<_C> = _C extends CollectionOptions.Meta ? _C : never
+
   export type HasLoc<L extends string[]> = {
     __loc__: L
   }
   export type HasT<T> = {
     __T__: T
   }
+
+  export type UAt<
+    F extends FTypes.FirestoreApp,
+    S extends STypes.RootOptions.All,
+    L extends Loc<S>,
+    _C = GetDeep<S, L>
+  > = EnsureOptions<_C>[typeof $schema]['__U__'] &
+    DocumentMeta<F> &
+    HasLoc<L> &
+    HasT<EnsureOptions<_C>[typeof $schema]['__T__']>
 
   type DocFieldToWrite<
     T,

--- a/src/firestore/STypes.ts
+++ b/src/firestore/STypes.ts
@@ -58,7 +58,7 @@ export declare namespace STypes {
   export namespace CollectionOptions {
     export type Meta = {
       [$schema]: DocumentSchema<any>
-      [$adapter]: Adapter<any, any, any, any> | null
+      [$adapter]: Adapter<any, any, any, any, any> | null
       [$docLabel]: string
       // [$collectionGroup]?: boolean
       [$allow]: AllowOptions
@@ -78,6 +78,7 @@ export declare namespace STypes {
   // export type CollectionInterface<T> = null
 
   export type Selectors<
+    T,
     L extends string[] | null,
     SL,
     F extends FTypes.FirestoreApp
@@ -86,7 +87,7 @@ export declare namespace STypes {
       ? (
           ...args: A
         ) => FTypes.Query<
-          U & STypes.DocumentMeta<F> & HasLoc<NonNullable<L>>,
+          U & STypes.DocumentMeta<F> & HasLoc<NonNullable<L>> & HasT<T>,
           F
         >
       : SL[K]
@@ -94,19 +95,21 @@ export declare namespace STypes {
 
   export type Adapter<
     T,
+    U,
     L extends string[] | null,
     SL,
     F extends FTypes.FirestoreApp
-  > = ((q: FTypes.Query<T>) => Adapted<L, SL, F>) & {
+  > = ((q: FTypes.Query<U>) => Adapted<T, L, SL, F>) & {
     __SL__: SL
   }
 
   export type Adapted<
+    T,
     L extends string[] | null,
     SL,
     F extends FTypes.FirestoreApp
   > = {
-    select: Selectors<L, SL, F>
+    select: Selectors<T, L, SL, F>
   }
 
   export type EnsureOptions<_C> = _C extends CollectionOptions.Meta ? _C : never

--- a/src/firestore/STypes.ts
+++ b/src/firestore/STypes.ts
@@ -42,7 +42,17 @@ export declare namespace STypes {
     export type All = Meta & Children
   }
 
-  export type DocumentSchema<T> = string & { __T__: T }
+  export type Decoder<T, U> = (
+    snapshot: FTypes.QueryDocumentSnap<T>,
+    options: FTypes.SnapshotOptions,
+  ) => U
+
+  export type DocumentSchema<T, U = T> = {
+    __T__: T
+    __U__: U
+    schema: string
+    decoder: Decoder<T, U> | undefined
+  }
 
   export namespace CollectionOptions {
     export type Meta = {
@@ -100,6 +110,9 @@ export declare namespace STypes {
 
   export type HasLoc<L extends string[]> = {
     __loc__: L
+  }
+  export type HasT<T> = {
+    __T__: T
   }
 
   type DocFieldToWrite<

--- a/src/firestore/_renderers/rules.ts
+++ b/src/firestore/_renderers/rules.ts
@@ -13,7 +13,7 @@ export const renderRules = (
   schema: STypes.DocumentSchema<any> | null,
   pIndent: number,
 ) => {
-  if (!is.string(schema)) {
+  if (!schema || !is.string(schema.schema)) {
     throw new Error(
       'documentSchema call expression not transformed and directly called',
     )
@@ -23,7 +23,7 @@ export const renderRules = (
 
   const validator = (arg: string) => `__validator_${index}__(${arg})`
 
-  const validatorBody = schema
+  const validatorBody = schema.schema
     .split('\n')
     .map((line, i, arr) => {
       return i === 0

--- a/src/firestore/controller/controller.ts
+++ b/src/firestore/controller/controller.ts
@@ -13,10 +13,10 @@ type GetDocT<
   D extends 'root' | FTypes.DocumentRef<unknown>
 > = D extends FTypes.DocumentRef<infer T> ? T : never
 
-type GetSchemaT<
+type GetSchemaU<
   C extends STypes.CollectionOptions.Meta,
   CS = C[typeof $schema]
-> = CS extends STypes.DocumentSchema<any> ? CS['__T__'] : never
+> = CS extends STypes.DocumentSchema<any> ? CS['__U__'] : never
 
 const getAdapted = <
   F extends FTypes.FirestoreApp,
@@ -49,7 +49,7 @@ type GetParentT<
   T extends STypes.HasLoc<string[]>,
   L extends string[] = OmitLast<T['__loc__']>,
   _C = GetDeep<S, L>
-> = SchemaTWithLoc<EnsureOptions<_C>, L>
+> = SchemaUWithLoc<EnsureOptions<_C>, L>
 
 type Parent = 'root' | FTypes.DocumentRef<STypes.HasLoc<string[]>>
 
@@ -64,10 +64,10 @@ type GetSL<
   ? {}
   : NonNullable<C[typeof $adapter]>['__SL__']
 
-type SchemaTWithLoc<
+type SchemaUWithLoc<
   C extends STypes.CollectionOptions.Meta,
   L extends string[]
-> = GetSchemaT<C> & STypes.HasLoc<L>
+> = GetSchemaU<C> & STypes.HasLoc<L> & STypes.HasT<C[typeof $schema]['__T__']>
 
 type CollectionController<
   F extends FTypes.FirestoreApp,
@@ -83,14 +83,14 @@ type CollectionController<
     collectionName: N,
   ) => {
     ref: FTypes.CollectionRef<
-      STypes.DocumentMeta<F> & SchemaTWithLoc<EnsureOptions<_C>, GetL<P, N>>,
+      STypes.DocumentMeta<F> & SchemaUWithLoc<EnsureOptions<_C>, GetL<P, N>>,
       F
     >
     select: STypes.Selectors<GetL<P, N>, GetSL<EnsureOptions<_C>>, F>
     doc: (
       id?: string,
     ) => FTypes.DocumentRef<
-      STypes.DocumentMeta<F> & SchemaTWithLoc<EnsureOptions<_C>, GetL<P, N>>,
+      STypes.DocumentMeta<F> & SchemaUWithLoc<EnsureOptions<_C>, GetL<P, N>>,
       F
     >
   }
@@ -99,7 +99,7 @@ type CollectionController<
     loc: L,
     path: string,
   ) => FTypes.DocumentRef<
-    STypes.DocumentMeta<F> & SchemaTWithLoc<EnsureOptions<_C>, L>,
+    STypes.DocumentMeta<F> & SchemaUWithLoc<EnsureOptions<_C>, L>,
     F
   >
 
@@ -107,12 +107,17 @@ type CollectionController<
     loc: L,
   ) => {
     query: FTypes.Query<
-      STypes.DocumentMeta<F> & SchemaTWithLoc<EnsureOptions<_C>, L>,
+      STypes.DocumentMeta<F> & SchemaUWithLoc<EnsureOptions<_C>, L>,
       F
     >
     select: STypes.Selectors<L, GetSL<EnsureOptions<_C>>, F>
   }
 }
+
+const createConverter = (decoder: STypes.Decoder<any, any>) => ({
+  fromFirestore: decoder,
+  toFirestore: (data: any) => data,
+})
 
 const getCollection = <
   F extends FTypes.FirestoreApp,
@@ -133,10 +138,17 @@ const getCollection = <
 
   const loc = [...parentLoc, collectionName] as L
   const collectionOptions = (getDeep(schemaOptions, loc as any) as unknown) as C
+  const { decoder } = collectionOptions[$schema]
 
-  const collectionRef = appOrParent.collection(
-    collectionName,
-  ) as FTypes.CollectionRef<STypes.DocumentMeta<F> & SchemaTWithLoc<C, L>, F>
+  const rawCollectionRef = appOrParent.collection(collectionName)
+
+  type CR = FTypes.CollectionRef<
+    STypes.DocumentMeta<F> & SchemaUWithLoc<C, L>,
+    F
+  >
+  const collectionRef = (decoder
+    ? (rawCollectionRef.withConverter as any)(createConverter(decoder))
+    : rawCollectionRef) as CR
 
   return { collectionOptions, collectionRef }
 }
@@ -180,7 +192,7 @@ const buildCollectionController = <
     type C = EnsureOptions<_C>
 
     const docRef = app.doc(path) as FTypes.DocumentRef<
-      STypes.DocumentMeta<F> & SchemaTWithLoc<C, L>,
+      STypes.DocumentMeta<F> & SchemaUWithLoc<C, L>,
       F
     >
 
@@ -197,11 +209,15 @@ const buildCollectionController = <
 
     const collectionId = loc[loc.length - 1]
     const collectionOptions = (getDeep(schemaOptions, loc) as unknown) as C
+    const { decoder } = collectionOptions[$schema]
 
-    const query = app.collectionGroup(collectionId) as FTypes.Query<
-      STypes.DocumentMeta<F> & SchemaTWithLoc<C, L>,
-      F
-    >
+    const rawQuery = app.collectionGroup(collectionId)
+
+    type Q = FTypes.Query<STypes.DocumentMeta<F> & SchemaUWithLoc<C, L>, F>
+    const query = (decoder
+      ? (rawQuery.withConverter as any)(createConverter(decoder))
+      : rawQuery) as Q
+
     const { select } = getAdapted<F, L, C>(collectionOptions, query)
 
     return { query, select }
@@ -212,35 +228,35 @@ const buildCollectionController = <
 
 const WithMeta = (FieldValue: FTypes.FieldValueClass) => {
   return {
-    toCreate: <T>(data: {}) =>
+    toCreate: <U extends STypes.HasT<unknown>>(data: {}) =>
       (({
         ...data,
         [_createdAt]: FieldValue.serverTimestamp(),
         [_updatedAt]: FieldValue.serverTimestamp(),
-      } as any) as T),
+      } as any) as U['__T__']),
 
-    toUpdate: <T>(data: {}) =>
+    toUpdate: <U extends STypes.HasT<unknown>>(data: {}) =>
       (({
         ...data,
         [_updatedAt]: FieldValue.serverTimestamp(),
-      } as any) as T),
+      } as any) as U['__T__']),
   }
 }
 
 const _mergeOption = { merge: true }
 
 export type Interactor<F extends FTypes.FirestoreApp> = {
-  create: <T>(
-    docRef: FTypes.DocumentRef<T, F>,
-    data: DataToCreate<T, F>,
+  create: <U extends STypes.HasT<unknown>>(
+    docRef: FTypes.DocumentRef<U, F>,
+    data: DataToCreate<U, F>,
   ) => FTypes.SetResult<F>
-  setMerge: <T>(
-    docRef: FTypes.DocumentRef<T, F>,
-    data: DataToUpdate<T, F>,
+  setMerge: <U extends STypes.HasT<unknown>>(
+    docRef: FTypes.DocumentRef<U, F>,
+    data: DataToUpdate<U, F>,
   ) => FTypes.SetResult<F>
-  update: <T>(
-    docRef: FTypes.DocumentRef<T, F>,
-    data: DataToUpdate<T, F>,
+  update: <U extends STypes.HasT<unknown>>(
+    docRef: FTypes.DocumentRef<U, F>,
+    data: DataToUpdate<U, F>,
   ) => FTypes.SetResult<F>
   delete: (docRef: FTypes.DocumentRef<any, F>) => FTypes.SetResult<F>
 }
@@ -249,28 +265,29 @@ export type TransactionController<F extends FTypes.FirestoreApp> = {
   get: <T>(
     docRef: FTypes.DocumentRef<T, F>,
   ) => Promise<FTypes.DocumentSnap<T, F>>
-  create: <T>(
-    docRef: FTypes.DocumentRef<T, F>,
-    data: DataToCreate<T, F>,
+  create: <U extends STypes.HasT<unknown>>(
+    docRef: FTypes.DocumentRef<U, F>,
+    data: DataToCreate<U, F>,
   ) => void
-  setMerge: <T>(
-    docRef: FTypes.DocumentRef<T, F>,
-    data: DataToUpdate<T, F>,
+  setMerge: <U extends STypes.HasT<unknown>>(
+    docRef: FTypes.DocumentRef<U, F>,
+    data: DataToUpdate<U, F>,
   ) => void
-  update: <T>(
-    docRef: FTypes.DocumentRef<T, F>,
-    data: DataToUpdate<T, F>,
+  update: <U extends STypes.HasT<unknown>>(
+    docRef: FTypes.DocumentRef<U, F>,
+    data: DataToUpdate<U, F>,
   ) => void
   delete: (docRef: FTypes.DocumentRef<any, F>) => void
 }
 
-type DataToCreate<T, F extends FTypes.FirestoreApp> = STypes.DocDataToWrite<
-  T,
-  F
->
-type DataToUpdate<T, F extends FTypes.FirestoreApp> = Partial<
-  DataToCreate<T, F>
->
+type DataToCreate<
+  U extends STypes.HasT<unknown>,
+  F extends FTypes.FirestoreApp
+> = STypes.DocDataToWrite<U['__T__'], F>
+type DataToUpdate<
+  U extends STypes.HasT<unknown>,
+  F extends FTypes.FirestoreApp
+> = Partial<DataToCreate<U, F>>
 
 const buildInteractor = <F extends FTypes.FirestoreApp>(
   FieldValue: FTypes.FieldValueClass<F>,
@@ -278,22 +295,28 @@ const buildInteractor = <F extends FTypes.FirestoreApp>(
   const withMeta = WithMeta(FieldValue)
 
   return {
-    create: <T>(docRef: FTypes.DocumentRef<T, F>, data: DataToCreate<T, F>) => {
-      const dataT = withMeta.toCreate<T>(data)
-      return docRef.set(dataT, {}) as FTypes.SetResult<F>
-    },
-
-    setMerge: <T>(
-      docRef: FTypes.DocumentRef<T, F>,
-      data: DataToUpdate<T, F>,
+    create: <U extends STypes.HasT<unknown>>(
+      docRef: FTypes.DocumentRef<U, F>,
+      data: DataToCreate<U, F>,
     ) => {
-      const dataT = withMeta.toUpdate<T>(data)
-      return docRef.set(dataT, _mergeOption) as FTypes.SetResult<F>
+      const dataT = withMeta.toCreate<U>(data)
+      return docRef.set(dataT as any, {}) as FTypes.SetResult<F>
     },
 
-    update: <T>(docRef: FTypes.DocumentRef<T, F>, data: DataToUpdate<T, F>) => {
-      const dataT = withMeta.toUpdate<T>(data)
-      return docRef.update(dataT) as FTypes.SetResult<F>
+    setMerge: <U extends STypes.HasT<unknown>>(
+      docRef: FTypes.DocumentRef<U, F>,
+      data: DataToUpdate<U, F>,
+    ) => {
+      const dataT = withMeta.toUpdate<U>(data)
+      return docRef.set(dataT as any, _mergeOption) as FTypes.SetResult<F>
+    },
+
+    update: <U extends STypes.HasT<unknown>>(
+      docRef: FTypes.DocumentRef<U, F>,
+      data: DataToUpdate<U, F>,
+    ) => {
+      const dataT = withMeta.toUpdate<U>(data)
+      return docRef.update(dataT as any) as FTypes.SetResult<F>
     },
 
     delete: (docRef: FTypes.DocumentRef<any, F>) =>
@@ -315,34 +338,37 @@ const buildTransactionController = <F extends FTypes.FirestoreApp>(
         ) as Promise<FTypes.DocumentSnap<T, F>>
       },
 
-      create: <T>(
-        docRef: FTypes.DocumentRef<T, F>,
-        data: DataToCreate<T, F>,
+      create: <U extends STypes.HasT<unknown>>(
+        docRef: FTypes.DocumentRef<U, F>,
+        data: DataToCreate<U, F>,
       ) => {
-        const dataT = withMeta.toCreate<T>(data)
-        return _tx.set((docRef as unknown) as fweb.DocumentReference<T>, dataT)
+        const dataT = withMeta.toCreate<U>(data)
+        return _tx.set(
+          (docRef as unknown) as fweb.DocumentReference<U>,
+          dataT as any,
+        )
       },
 
-      setMerge: <T>(
-        docRef: FTypes.DocumentRef<T, F>,
-        data: DataToUpdate<T, F>,
+      setMerge: <U extends STypes.HasT<unknown>>(
+        docRef: FTypes.DocumentRef<U, F>,
+        data: DataToUpdate<U, F>,
       ) => {
-        const dataT = withMeta.toUpdate<T>(data)
+        const dataT = withMeta.toUpdate<U>(data)
         return _tx.set(
-          (docRef as unknown) as fweb.DocumentReference<T>,
-          dataT,
+          (docRef as unknown) as fweb.DocumentReference<U>,
+          dataT as any,
           _mergeOption,
         )
       },
 
-      update: <T>(
-        docRef: FTypes.DocumentRef<T, F>,
-        data: DataToUpdate<T, F>,
+      update: <U extends STypes.HasT<unknown>>(
+        docRef: FTypes.DocumentRef<U, F>,
+        data: DataToUpdate<U, F>,
       ) => {
-        const dataT = withMeta.toUpdate<T>(data)
+        const dataT = withMeta.toUpdate<U>(data)
         return _tx.update(
-          (docRef as unknown) as fweb.DocumentReference<T>,
-          dataT,
+          (docRef as unknown) as fweb.DocumentReference<U>,
+          dataT as any,
         )
       },
 

--- a/src/firestore/controller/controller.ts
+++ b/src/firestore/controller/controller.ts
@@ -53,7 +53,7 @@ type GetParentT<
 
 type Parent = 'root' | FTypes.DocumentRef<STypes.HasLoc<string[]>>
 
-type EnsureOptions<_C> = _C extends STypes.CollectionOptions.Meta ? _C : never
+type EnsureOptions<_C> = STypes.EnsureOptions<_C>
 
 type GetL<P extends Parent, N> = [...GetPL<P>, N]
 type GetPL<P extends Parent> = P extends 'root' ? [] : GetDocT<P>['__loc__']

--- a/src/firestore/factories/adapter.ts
+++ b/src/firestore/factories/adapter.ts
@@ -17,10 +17,10 @@ export const $collectionAdapter = <T>() => {
   }) => {
     const adapter = <F extends FTypes.FirestoreApp>(
       q: FTypes.Query<T, F>,
-    ): STypes.Adapted<null, SL, F> => ({
-      select: selectors(q) as STypes.Selectors<null, SL, F>,
+    ): STypes.Adapted<T, null, SL, F> => ({
+      select: selectors(q) as STypes.Selectors<T, null, SL, F>,
     })
 
-    return adapter as STypes.Adapter<T, null, SL, FTypes.FirestoreApp>
+    return adapter as STypes.Adapter<T, unknown, null, SL, FTypes.FirestoreApp>
   }
 }

--- a/src/firestore/factories/firestore-schema.ts
+++ b/src/firestore/factories/firestore-schema.ts
@@ -1,7 +1,9 @@
 import { STypes } from '../STypes'
 
-export function $documentSchema<T>(): STypes.DocumentSchema<T> {
-  return (null as unknown) as STypes.DocumentSchema<T>
+export function $documentSchema<T, U = T>(options?: {
+  decoder?: STypes.Decoder<T, U>
+}): STypes.DocumentSchema<T, U> {
+  return (null as unknown) as STypes.DocumentSchema<T, U>
 }
 
 export const createFirestoreSchema = <S extends STypes.RootOptions.All>(

--- a/src/firestore/factories/firestore-schema.ts
+++ b/src/firestore/factories/firestore-schema.ts
@@ -3,7 +3,7 @@ import { STypes } from '../STypes'
 export function $documentSchema<T, U = T>(options?: {
   decoder?: STypes.Decoder<T, U>
 }): STypes.DocumentSchema<T, U> {
-  return (null as unknown) as STypes.DocumentSchema<T, U>
+  return (options ?? {}) as STypes.DocumentSchema<T, U>
 }
 
 export const createFirestoreSchema = <S extends STypes.RootOptions.All>(


### PR DESCRIPTION
- `withConverter` を使用
  - `FromFirestore` のみ
  - `toFirestore` は `setMerge` の Partial なオブジェクトや `FieldValue` に対応するのが難しいので省略